### PR TITLE
Add type hints to remove reflection warnings

### DIFF
--- a/src/zen/cli.clj
+++ b/src/zen/cli.clj
@@ -49,7 +49,7 @@
                       clojure.java.io/file
                       file-seq
                       (filter #(clojure.string/ends-with? % ".edn"))
-                      (map #(relativize (.getAbsolutePath %)))
+                      (map (fn [^java.io.File f] (relativize (.getAbsolutePath f))))
                       (remove clojure.string/blank?)
                       (map #(subs % 1)))
         namespaces (map #(-> %

--- a/src/zen/dev.clj
+++ b/src/zen/dev.clj
@@ -7,7 +7,7 @@
 (defn make-ns-name [paths filename]
   (when-let [nm (->> paths
                      (keep io/as-file)
-                     (map #(.getPath %)) #_"NOTE: path sanitization"
+                     (map (fn [^java.io.File f] (.getPath f))) #_"NOTE: path sanitization"
                      (map (fn [p]
                             (when (str/starts-with? filename p)
                               (subs filename (inc (count p)) (- (count filename) 4)))))
@@ -29,7 +29,7 @@
   (swap! ztx assoc-in [:ns-reloads ns-sym] (hash (get-in @ztx [:ns ns-sym])))
   (zen.core/read-ns ztx (symbol ns-sym)))
 
-(defn handle-updates [ztx paths htx {file :file kind :kind}]
+(defn handle-updates [ztx paths htx {^java.io.File file :file kind :kind}]
   (let [filename (-> (.getPath file)
                      ;; this is strange prefix in macos
                      (str/replace  #"^/private" ""))]

--- a/src/zen/package.clj
+++ b/src/zen/package.clj
@@ -7,7 +7,6 @@
             [zen.utils])
   (:import java.io.File))
 
-
 (defn sh! [& args]
   (println "$" (str/join " " args))
   (let [result (apply shell/sh args)]
@@ -87,7 +86,7 @@
 
 (defn zen-init! [root & {:keys [package-name]}]
   (let [not-empty-zen-dir? (->> (file-seq (io/file root))
-                                (filter #(.isFile %))
+                                (filter (fn [^java.io.File f] (.isFile f)))
                                 seq)]
     (if not-empty-zen-dir?
       nil

--- a/src/zen/store.clj
+++ b/src/zen/store.clj
@@ -185,11 +185,11 @@
   (let [modules (io/file (str path "/node_modules"))]
     (when (and (.exists modules) (.isDirectory modules))
       (->> (.listFiles modules)
-           (mapcat (fn [x]
+           (mapcat (fn [^java.io.File x]
                      (if (and (.isDirectory x) (str/starts-with? (.getName x) "@"))
                        (.listFiles x)
                        [x])))
-           (filter #(.isDirectory %))))))
+           (filter (fn [^java.io.File x] (.isDirectory x)))))))
 
 (defn mk-full-path [zen-path file-path]
   (str zen-path "/" file-path))
@@ -278,7 +278,7 @@
 
 (defn read-ns [ctx nm & [opts]]
   (let [pth (str (str/replace (str nm) #"\." "/") ".edn")]
-    (if-let [{:keys [file zen-path]} (find-file&path ctx pth)]
+    (if-let [{:keys [^java.io.File file zen-path]} (find-file&path ctx pth)]
       (try
         (let [content (slurp file)
               env (:env @ctx)

--- a/src/zen/store.clj
+++ b/src/zen/store.clj
@@ -237,7 +237,7 @@
 
 (defn find-file&path [ctx pth]
   (or (when-let [resource-file (io/resource pth)]
-        {:file resource-file})
+        {:file (io/file resource-file)})
       (when-let [zen-path (find-path (concat (mapcat expand-package-path (:package-paths @ctx))
                                              (:paths @ctx)
                                              (map unzip-to-cache-dir (:zip-paths @ctx)))

--- a/src/zen/utils.clj
+++ b/src/zen/utils.clj
@@ -161,7 +161,7 @@
       (name name-part))
     (merge (meta ns-part) (meta name-part))))
 
-(defn string->md5 [s]
+(defn string->md5 [^String s]
   (let [md5-digest (doto (java.security.MessageDigest/getInstance "MD5")
                      (.update (.getBytes s)))]
     (format "%032x" (BigInteger. 1 (.digest md5-digest)))))
@@ -187,15 +187,16 @@
 (defn copy-file [src dest]
   (java.nio.file.Files/copy (.toPath (io/file src))
                             (.toPath (io/file dest))
+                            ^"[Ljava.nio.file.CopyOption;"
                             (into-array java.nio.file.CopyOption
                                         [(java.nio.file.StandardCopyOption/REPLACE_EXISTING)])))
 
 
 (defn copy-directory [from to]
-  (let [from (File. from)
-        to (File. to)]
+  (let [from (io/file from)
+        to (io/file to)]
     (when (not (.exists to)) (.mkdirs to))
-    (doseq [file (.listFiles from)]
+    (doseq [^java.io.File file (.listFiles from)]
       (if (.isDirectory file)
         (copy-directory (.getPath file) (str to "/" (.getName file)))
         (copy-file (.getPath file) (str to "/" (.getName file)))))))

--- a/test/zen/test_utils.clj
+++ b/test/zen/test_utils.clj
@@ -33,11 +33,11 @@
      (:errors res#)))
 
 
-(defn zip-entries [filename]
+(defn zip-entries [^String filename]
   (let [zf (java.util.zip.ZipFile. filename)]
     (try (->> (.entries zf)
               enumeration-seq
-              (mapv #(.getName %)))
+              (mapv (fn [^java.util.zip.ZipEntry e] (.getName e))))
          (finally (.close zf)))))
 
 


### PR DESCRIPTION
These type hints are needed to be able to compile `zen.jar` as Graal binary.
The only exception is `zen.test-utils` namespace, type hints are added there just because.