### PR TITLE
 zen.package/zen-pull-deps-recur! shouldn't do rm -rf, should fail instead

### DIFF
--- a/src/zen/package.clj
+++ b/src/zen/package.clj
@@ -131,7 +131,7 @@
           :else
           (do
             (when (.exists dep-dir)
-              (sh-with-env! "rm" "-rf" dep-name-str :dir root))
+              (throw (Exception. (format "Directory %s already exists" dep-dir-path))))
             (sh-with-env! "git" "clone" "--depth=1" (str dep-url) dep-name-str
                           :dir root)
             (recur


### PR DESCRIPTION
zen.package/zen-pull-deps-recur! will fail instead of deleting