### PR TITLE
Use jgit instead of shell calls

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,9 @@
  :deps {org.clojure/clojure  {:mvn/version "1.11.1"}
         borkdude/edamame     {:mvn/version "1.3.22"}
         hawk/hawk            {:mvn/version "0.2.11"}
-        healthsamurai/matcho {:mvn/version "0.3.10"}}
+        healthsamurai/matcho {:mvn/version "0.3.10"}
+        clj-jgit/clj-jgit    {:git/url "https://github.com/octoshikari/clj-jgit"
+                              :sha "b30da96a6b110a47cbdc8c28bdaeb0653898c216"}}
 
  :aliases
  {:nrepl

--- a/deps.edn
+++ b/deps.edn
@@ -7,8 +7,7 @@
         borkdude/edamame     {:mvn/version "1.3.22"}
         hawk/hawk            {:mvn/version "0.2.11"}
         healthsamurai/matcho {:mvn/version "0.3.10"}
-        clj-jgit/clj-jgit    {:git/url "https://github.com/octoshikari/clj-jgit"
-                              :sha "b30da96a6b110a47cbdc8c28bdaeb0653898c216"}}
+        clj-jgit/clj-jgit {:mvn/version "1.1.0-SNAPSHOT"}}
 
  :aliases
  {:nrepl

--- a/kaocha.edn
+++ b/kaocha.edn
@@ -7,7 +7,7 @@
 
   :plugins                     [:hooks
                                ;; :kaocha.plugin/filter
-                               ;; :kaocha.plugin/capture-output
+                                ;; :kaocha.plugin/capture-output
                                 :kaocha.plugin/print-invocations
                                 :kaocha.plugin/profiling]
   :tests                       [{:id   :unit

--- a/src/zen/cli.clj
+++ b/src/zen/cli.clj
@@ -10,6 +10,7 @@
    [zen.changes]
    [zen.cli.output]
    [zen.core]
+   [zen.git :as git]
    [zen.package]
    [zen.utils :as utils]
    [zen.v2-validation]))
@@ -217,9 +218,9 @@
   ([new-ztx opts]
    (let [pwd     (get-pwd opts)
          new-ztx (load-used-namespaces new-ztx opts)
-         _stash! (clojure.java.shell/sh "git" "stash" :dir pwd) #_"NOTE: should this logic be moved to zen.package?"
+         _stash! (git/stash pwd)
          old-ztx (load-used-namespaces (load-ztx opts) opts)
-         _pop!   (clojure.java.shell/sh "git" "stash" "pop" :dir pwd)]
+         _pop!   (git/stash-pop pwd)]
      (zen.changes/check-changes old-ztx new-ztx))))
 
 

--- a/src/zen/git.clj
+++ b/src/zen/git.clj
@@ -1,0 +1,71 @@
+(ns zen.git
+  (:require [clj-jgit.porcelain :as git]
+            [clojure.java.io :as io])
+  (:import java.io.File
+           (org.eclipse.jgit.transport
+            RemoteConfig)
+           (org.eclipse.jgit.api Git)))
+
+
+(defn init-repo
+  ^Git [^File dir & {:keys [branch] :or {branch "main"}}]
+  (println (format "Init repository in %s with branch %s" (str dir) branch))
+  (git/git-init :branch branch :dir dir))
+
+(defn pull
+  ^Git [^File dir]
+  (println (format "Pull repository changes %s" dir))
+  (-> dir
+      git/load-repo
+      git/git-pull))
+
+(defn init-template
+  ^Git [^File root repository-url]
+  (println (format "Cloning [%s] into [%s]" repository-url root))
+  (if (.exists root)
+    (git/load-repo root)
+    (git/git-clone repository-url :dir root :branch nil :clone-all? false)))
+
+
+(defn get-remote-url
+  ^String [^File dir ^String remote-name]
+  (->> (git/load-repo dir)
+       .remoteList
+       .call
+       (filter (fn [^RemoteConfig r]
+                 (= remote-name (.getName r))))
+       (map (fn [^RemoteConfig r]
+              (.getURIs r)))
+       first
+       first
+       .toString))
+
+(defn stash
+  [^File dir]
+  (git/git-stash-create (git/load-repo dir)))
+
+(defn stash-pop
+  [^File dir]
+  (let [repo (git/load-repo dir)]
+    (when (seq (git/git-stash-list repo))
+      (git/git-stash-pop (git/load-repo dir)))))
+
+(defn clone
+  ^Git [^File dir ^String uri & {:keys [sub-dir]}]
+  (println (format "Cloning [%s] into [%s]" uri (str (if sub-dir (io/file dir sub-dir) dir))))
+  (git/git-clone  uri
+                  :dir  (if sub-dir (io/file dir sub-dir) dir)
+                  :depth 1
+                  :branch nil))
+
+(defn add
+  [^File dir files]
+  (println (format "Add files in repository %s" dir))
+  (-> (git/load-repo dir)
+      (git/git-add files)))
+
+(defn commit
+  [^File dir message]
+  (println (format "Commit in repository %s" dir))
+  (-> (git/load-repo dir)
+      (git/git-commit message)))

--- a/test/zen/package_test.clj
+++ b/test/zen/package_test.clj
@@ -1,22 +1,12 @@
 (ns zen.package-test
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]
    [clojure.test :as t]
    [matcho.core :as matcho]
    [zen.core :as zen]
    [zen.package :as sut]
    [zen.store]
    [zen.test-utils]))
-
-
-(defn get-git-hash [path]
-  (as-> (slurp (str path "/.git/HEAD")) v
-    (str/trim-newline v)
-    (subs v 5)
-    (str path "/.git/" v)
-    (slurp v)
-    (str/trim-newline v)))
 
 
 (def test-zen-repos

--- a/test/zen/test_utils.clj
+++ b/test/zen/test_utils.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [clojure.test :refer [is]]
             [matcho.core :as matcho]
+            [zen.git :as git]
             [zen.package]
             [zen.utils :as utils])
   (:import java.io.File))
@@ -88,13 +89,13 @@
 
 (defn git-commit [dir to-add message]
   (let [to-add-seq (if (sequential? to-add) to-add [to-add])]
-    (apply shell/sh (concat ["git" "add"] to-add-seq [:dir dir]))
-    (shell/sh "git" "commit" "-m" message :dir dir)))
+    (git/add dir to-add-seq)
+    (git/commit dir message)))
 
 
 (defn git-init-commit [dir]
-  (shell/sh "git" "add" "." :dir dir)
-  (shell/sh "git" "commit" "-m" "\"Initial commit\"" :dir dir))
+  (git/add dir ["."])
+  (git/commit dir "Initial commit"))
 
 
 (defn mk-module-dir-path [root-dir-path module-name]


### PR DESCRIPTION
Switch to use JGit clojure wrapper instead of shell calls. Create new `zen.git` namespace with prepared subset of features with additional `println` for simple logging. Temporary use my fork for clj-jgit. PR in original repo created and wait approval
- https://github.com/clj-jgit/clj-jgit/pull/81